### PR TITLE
Use staged generics

### DIFF
--- a/HACK/ocamlc
+++ b/HACK/ocamlc
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec metaocamlc "$@"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ like how the Haskell compiler can derive [Generic](https://hackage.haskell.org/p
 **Warning:** (unlike serde, which is a fully-featured framework) compact is not remotely production-ready.
 Its encodings are pretty stupid, and cannot be relied upon to be the same across different versions of the OCaml
 compiler, or of the compact or staged-generics libraries.
+Furthermore, it doesn't work for types that can be an arbitrary length (like lists), and can't even encode things that
+take more than 63 bits.
 
 ## Build instructions
 Compact requires OCaml with both the [modular implicits](https://github.com/ocamllabs/ocaml-modular-implicits)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # compact
+
+## Build instructions
+The `HACK` directory contains a shim to convince Dune to use `metaocamlc` instead of `ocamlc`.
+You need to add it to your path. For example:
+
+```bash
+PATH="$(pwd)/HACK:$PATH" dune build
+```
+
+There is probably a better way of doing this.
+It appears to be unnecessary in modern versions of Dune, but those don't support this old version of OCaml.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,32 @@
 # compact
+Compact derives basic binary encodings for arbitrary data types,
+using [staged generics](https://github.com/modular-implicits/staged-generics).
+
+Compact is a bit like the [serde](https://serde.rs/) library in Rust
+(which also provides generic serialisation and deserialisation for arbitrary types).
+Serde uses procedural macros to derive implementations for user-defined data types,
+but compact uses the staged generics interface, which is more declarative.
+
+Unlike serde, which requires just one line, you still have to manually write instances of Sum or Product to use compact.
+However, these instances could then be used for all kinds of generic code.
+In future, the OCaml compiler could automatically derive these generic instances,
+like how the Haskell compiler can derive [Generic](https://hackage.haskell.org/package/base/docs/GHC-Generics.html).
+
+**Warning:** (unlike serde, which is a fully-featured framework) compact is not remotely production-ready.
+Its encodings are pretty stupid, and cannot be relied upon to be the same across different versions of the OCaml
+compiler, or of the compact or staged-generics libraries.
 
 ## Build instructions
+Compact requires OCaml with both the [modular implicits](https://github.com/ocamllabs/ocaml-modular-implicits)
+and [BER MetaOCaml](https://okmij.org/ftp/meta-programming/ber-design.pdf) extensions.
+
+You can install that variant of OCaml using `opam`:
+
+```bash
+opam switch add modular-implicits-ber 4.02.1+modular-implicits-ber
+```
+
+Getting this library to build is a bit tricky.
 The `HACK` directory contains a shim to convince Dune to use `metaocamlc` instead of `ocamlc`.
 You need to add it to your path. For example:
 

--- a/compact.ml
+++ b/compact.ml
@@ -1,99 +1,132 @@
-module Generic = Generics_core
+open Imp.Any
 
-let ((lor), (land), (asr), (lsr), (lsl), (lxor), lnot, zero, one) = Int64.
-  (logor, logand, shift_right, shift_right_logical, shift_left, logxor, lognot, of_int 0, of_int 1)
-
-module type Compact = sig
+module type Product = sig
+  type a
+  type b
   type t
-
-  (* must return a number between 0 and 2^bit_width *)
-  val compress : t -> int64
-
-  (* must only depend on the 2^bit_width least significant bits *)
-  val decompress : int64 -> t
-
-  (* TODO: is int64 overflow defined behaviour in ocaml? *)
-  (* must be <= 64 *)
-  val bit_width : int
+  val construct : a code -> b code -> t code
+  val deconstruct : t code -> a code * b code
 end
 
-implicit module Compact_Char: Compact with type t = char = struct
-  type t = char
-  let compress x = Int64.of_int (Char.code x)
-  let decompress x = Char.chr (Int64.to_int x)
-  let bit_width = 8
-end
-
-implicit module Compact_Unit : Compact with type t = unit
+implicit module Pair {A: Any} {B: Any}
+:  Product
+  with type t = A.t * B.t
+  and type a = A.t
+  and type b = B.t
 = struct
-  type t = unit
-  let compress () = zero
-  let decompress _ = ()
-  let bit_width = 0
+  type t = A.t * B.t
+  type a = A.t
+  type b = B.t
+  let construct a b = .< .~a, .~b >.
+  let deconstruct p = .< fst .~p >., .< snd .~p >.
 end
 
-implicit module Compact_Sum {X: Compact} {Y: Compact} :
-  Compact with type t = (X.t, Y.t) Generic.sum
+module type Sum = sig
+  type a
+  type b
+  type t
+  val construct_a : a code -> t code
+  val construct_b : b code -> t code
+  val match_ :
+    (a code -> 'r code) ->
+    (b code -> 'r code) ->
+    t code ->
+    'r code
+end
+
+implicit module Option {A: Any}
+: Sum
+  with type t = A.t option
+  and type a = A.t
+  and type b = unit
 = struct
-  type t = (X.t, Y.t) Generic.sum
+  type t = A.t option
+  type a = A.t
+  type b = unit
+  let construct_a a = .< Some .~a >.
+  let construct_b _ = .< None >.
+  let match_ fa fb x = .<
+    match .~x with
+    | Some a -> .~(fa .< a >.)
+    | None -> .~(fb .< () >.)
+  >.
+end
 
-  (* note: if x and y don't have the same bit width, we just implicitly left-pad with 0s
-     e.g. if x is 5 bits wide and y is 7 bits wide, then:
-
-     Left x  -> 00xxxxx0
-     Right y -> yyyyyyy1
+module type Sized = sig
+  (* Compute some notion of "size", in arbitrary units.
+     This will bare little relation to the actual amount of memory the object takes up.
    *)
-
-  let compress = function
-    | Generic.Left x -> X.compress x lsl 1 lor zero
-    | Generic.Right y -> Y.compress y lsl 1 lor one
-
-  let decompress c =
-    let flag = c land one in
-    let c' = c lsr 1 in
-    if flag = zero
-    then Generic.Left (X.decompress c')
-    else Generic.Right (Y.decompress c')
-
-  let bit_width = 1 + max X.bit_width Y.bit_width
+  type t
+  val size : t -> int
 end
 
-implicit module Compact_Prod {X: Compact} {Y: Compact} :
-  Compact with type t = (X.t, Y.t) Generic.prod
+module type Sized_ = sig
+  type t
+  val size : t code -> int code
+end
+
+implicit module Sized_Product
+  {P: Product}
+  {A: Sized_ with type t = P.a}
+  {B: Sized_ with type t = P.b}
+  : Sized_ with type t = P.t
 = struct
-  type t = (X.t, Y.t) Generic.prod
-
-  let compress (Generic.Prod (x, y)) =
-    X.compress x lsl Y.bit_width lor Y.compress y
-
-  let decompress c =
-    Generic.Prod (X.decompress (c lsr Y.bit_width), Y.decompress c)
-
-  let bit_width = X.bit_width + Y.bit_width
+  type t = P.t
+  let size x =
+    let (a, b) = P.deconstruct x in
+    .< .~(A.size a) + .~(B.size b) >.
 end
 
-implicit module Compact_Basic {X: Compact} :
-  Compact with type t = X.t Generic.basic
+implicit module Sized_Sum
+  {S: Sum}
+  {A: Sized_ with type t = S.a}
+  {B: Sized_ with type t = S.b}
+  : Sized_ with type t = S.t
 = struct
-  type t = X.t Generic.basic
-  let compress (Generic.Basic (_, x)) = X.compress x
-  (* TODO: what to do about the label here? *)
-  let decompress c = Generic.Basic ("%decompressed", (X.decompress c))
-  let bit_width = X.bit_width
+  type t = S.t
+  let size x = 
+    .< 1 + .~(S.match_ A.size B.size x) >.
 end
 
-(* not marked implicit to avoid overlapping instances
-   You can opt-in if you want to use this, by writing:
-    ```
-    let implicit module Compact_Generic = Compact_Generic in
-    (* ... *)
-    ```
+(* The __basic__ marker acts as a "stop" for the implicit module resolver.
+   Without it, the implicit functors Sized_ and Sized_Basic would form an infinite loop
  *)
-module Compact_Generic {X: Generic.Generic} {XRep: Compact with type t = X.rep}
-  : Compact with type t = X.t
-= struct
-  type t = X.t
-  let compress x = XRep.compress (X.toRep x)
-  let decompress c = X.fromRep (XRep.decompress c)
-  let bit_width = XRep.bit_width
+module type Sized_Basic = sig
+  include Sized
+  val __basic__ : unit
 end
+
+implicit module Sized_Basic
+  {T: Sized_Basic}
+  : Sized_ with type t = T.t = struct
+  type t = T.t
+  let size x = .< T.size .~x >.
+end
+
+implicit module Sized_Unit : Sized_Basic with type t = unit = struct
+  type t = unit
+  let __basic__ = ()
+  let size () = 1
+end
+
+implicit module Sized_Int : Sized_Basic with type t = int = struct
+  type t = int
+  let __basic__ = ()
+  let size _ = 4
+end
+
+implicit module Sized_List {S: Sized} : Sized_Basic with type t = S.t list = struct
+  type t = S.t list
+  let __basic__ = ()
+  (* until we have some way of dealing with inductive types, this will have to do *)
+  let rec size = function
+    | [] -> 1
+    | x :: xs -> 1 + S.size x + size xs
+end
+
+implicit module Sized_ {S: Sized_} : Sized with type t = S.t = struct
+  type t = S.t
+  let size x = Runcode.run (S.size .< x >.)
+end
+
+let size {S: Sized} x = S.size x

--- a/compact.opam
+++ b/compact.opam
@@ -4,9 +4,9 @@ synopsis: "??"
 version: "dev"
 maintainer: "yallop@gmail.com"
 authors: ["Patrick Reader"]
-homepage: "https://github.com/modular-implicits/oi"
-dev-repo: "git+https://github.com/modular-implicits/oi.git"
-bug-reports: "http://github.com/modular-implicits/oi/issues"
+homepage: "https://github.com/modular-implicits/compact"
+dev-repo: "git+https://github.com/modular-implicits/compact.git"
+bug-reports: "http://github.com/modular-implicits/compact/issues"
 license: "GPL-3.0-only"
 build: [
   ["dune" "subst"] {dev}
@@ -18,4 +18,5 @@ depends: [
   "ocaml-variants"
      { = "4.02.1+modular-implicits-ber" }
   "generics-core"
+  "imp"
 ]

--- a/compact.opam
+++ b/compact.opam
@@ -17,6 +17,6 @@ depends: [
   "dune" {build}
   "ocaml-variants"
      { = "4.02.1+modular-implicits-ber" }
-  "generics-core"
+  "staged-generics"
   "imp"
 ]

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (library
  (name compact)
- (libraries generics-core imp)
+ (libraries staged-generics imp)
  (modules Compact))

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (library
  (name compact)
- (libraries generics-core)
+ (libraries generics-core imp dynlink metaocaml)
  (modules Compact))

--- a/dune
+++ b/dune
@@ -1,4 +1,4 @@
 (library
  (name compact)
- (libraries generics-core imp dynlink metaocaml)
+ (libraries generics-core imp)
  (modules Compact))

--- a/tests/dune
+++ b/tests/dune
@@ -3,4 +3,4 @@
  (modules test)
  ; MetaOCaml 4.02 only properly supports bytecode mode
  (modes byte)
- (libraries metaocaml compact dynlink))
+ (libraries compact))

--- a/tests/dune
+++ b/tests/dune
@@ -1,5 +1,6 @@
 (test
  (name test)
  (modules test)
- (modes native)
- (libraries compact))
+ ; MetaOCaml 4.02 only properly supports bytecode mode
+ (modes byte)
+ (libraries metaocaml compact dynlink))

--- a/tests/dune
+++ b/tests/dune
@@ -3,4 +3,4 @@
  (modules test)
  ; MetaOCaml 4.02 only properly supports bytecode mode
  (modes byte)
- (libraries compact))
+ (libraries compact staged-generics))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,1 +1,8 @@
-let () = assert true
+open Imp.Any
+open Compact
+
+let thing : (int * int) option = Some (3, 6)
+
+let () = Printf.printf "%d" (size thing)
+
+let () = ignore (module Any_Int : Any)

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,8 +1,8 @@
 open Imp.Any
 open Compact
 
-let thing : (int * int) option = Some (3, 6)
+let thing : (int * int) option = Some (0, 0)
 
-let () = Printf.printf "%d" (size thing)
+let () = Printf.printf "%d\n" (size thing)
 
 let () = ignore (module Any_Int : Any)

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,8 +1,10 @@
 open Imp.Any
 open Compact
 
-let thing : (int * int) option = Some (0, 0)
+let thing : (char * char) option = Some ('a', 'x')
 
-let () = Printf.printf "%d\n" (size thing)
+let () = Printf.printf "%d\n" (Int64.to_int (encode thing))
+
+let () = assert (decode (encode thing) = thing)
 
 let () = ignore (module Any_Int : Any)

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -1,5 +1,6 @@
 open Imp.Any
 open Compact
+open implicit Staged_generics.Instances
 
 let thing : (char * char) option = Some ('a', 'x')
 


### PR DESCRIPTION
I defined a different kind of generic interface to make using staging with it easier. It should probably be extracted, but where?:
- into a new "staged generics" library, or
- into @dvlasits' generics library?